### PR TITLE
Small changes to make it work on default PCP installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 
 # Debug files
 *.dSYM/
+
+.idea/*

--- a/heatmap.sh
+++ b/heatmap.sh
@@ -6,7 +6,7 @@ INSTANCE=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`
 S3BUCKET="s3://nflx.cldperf.test/pcp/$INSTANCE"
 # /usr/bin/s3cp README $S3BUCKET/README1
 #DIR
-WEBDIR=/usr/share/pcp/jsdemos/heatmap
+WEBDIR=/usr/share/pcp/webapps/heatmap
 WDIR=/mnt/logs/pcp/generic/HEATMAP
 BDIR=/var/lib/pcp/pmdas/generic/BINHeatMap
 #FILE
@@ -33,7 +33,7 @@ fi
 timeout 20 /usr/bin/perf script -i $PERF| awk '{ gsub(/:/, "") } $5 ~ /issue/ { ts[$6, $10] = $4 } $5 ~ /complete/ { if (l = ts[$6, $9]) { printf "%.f %.f\n", $4 * 1000000, ($4 - l) * 1000000; ts[$6, $10] = 0 } }' > $WDIR/out.lat_us
 #
 $BDIR/trace2heatmap.pl --unitstime=us --unitslat=us --grid --maxlat=100000 $WDIR/out.lat_us >$SVG
-/usr/bin/s3cp $SVG $S3BUCKET/heatmap-$TS.svg &> /dev/null
+#/usr/bin/s3cp $SVG $S3BUCKET/heatmap-$TS.svg &> /dev/null
 #clean up
-/bin/rm $PERF
-/bin/rm $WDIR/out.lat_us
+#/bin/rm $PERF
+#/bin/rm $WDIR/out.lat_us

--- a/systack.sh
+++ b/systack.sh
@@ -30,8 +30,7 @@ for pid in $(pgrep -x java); do
         mapfile=/tmp/perf-$pid.map
         if [ -e $PMADIR ]; then
                 cd $PMADIR
-                # XXX todo: set JAVA_HOME based on running pid
-                JAVA_HOME=/usr/lib/jvm/java-8-oracle
+                JAVA_HOME=/usr/lib/jvm/jdk1.8.0_45/
 		if [ -d $JAVA_HOME ]; then
 			# run as java user to avoid "well-known file is not secure" error
 			JAVA_USER=$(ps ho user -p $pid)

--- a/systack.sh
+++ b/systack.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # environment
-. /etc/profile.d/netflix_environment.sh
+#. /etc/profile.d/netflix_environment.sh
 PATH=/bin:/usr/bin:$PATH
 TS=$(date +%Y-%m-%d_%T)
 HOSTNAME=$(uname -n)
 PMADIR=/usr/lib/jvm/perf-map-agent
-WEBDIR=/usr/share/pcp/jsdemos/systack
+WEBDIR=/usr/share/pcp/webapps/systack
 WDIR=/mnt/logs/pcp/generic/SYSTACK
 BDIR=/var/lib/pcp/pmdas/generic/BINFlameGraph
 SVG=$WEBDIR/systack.svg
@@ -47,7 +47,7 @@ done
 # generate flame graph and stash it away with the folded profile on s3
 timeout 20 perf script -i $PERF | $BDIR/stackcollapse-perf.pl | grep -v cpu_idle > $FOLDED
 $BDIR/flamegraph.pl --color=java --title="CPU Flame Graph (no idle): $HOSTNAME, $TS" < $FOLDED > $SVG
-s3cp $SVG $S3BUCKET/perf-cpu-stacks-$TS.svg &> /dev/null
-s3cp $FOLDED $S3BUCKET/perf-cpu-stacks-$TS.folded &> /dev/null
+#s3cp $SVG $S3BUCKET/perf-cpu-stacks-$TS.svg &> /dev/null
+#s3cp $FOLDED $S3BUCKET/perf-cpu-stacks-$TS.folded &> /dev/null
 
 # $PERF file left behind for debug or custom reports (will be overwritten next time)


### PR DESCRIPTION
Hi,

I know that this is WIP but this might be useful to others. I needed few changes to make flame graphs work on default PCP+Vector installation (unless I did compile&install it incorrectly in the first place :)). Also you might want to remove references to Netflix environment and S3 buckets :)